### PR TITLE
refactor: align product grid layout with quick view

### DIFF
--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import Link from 'next/link';
 import { ProductCardImage } from '@/components/ui/ProductImage';
-import { ShoppingCart, Eye } from 'lucide-react';
+import { ShoppingCart } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter } from '@/components/ui/card';
 import { Product } from '@/types';
@@ -32,94 +32,66 @@ export function ProductCard({ product, viewMode = 'grid' }: ProductCardProps) {
     window.open(url, '_blank');
   };
 
-  const formatPrice = (price: number) => {
-    return new Intl.NumberFormat('pt-BR', {
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat('pt-BR', {
       style: 'currency',
       currency: 'BRL',
     }).format(price);
-  };
 
   if (viewMode === 'list') {
     return (
-      <div className="group bg-white rounded-xl overflow-hidden hover:shadow-xl transition-all duration-500 h-full flex flex-row border border-gray-100 hover:border-red-200 hover:-translate-y-1">
-        <Link href={`/produtos/${product.slug}`}>
-          <div className="relative w-48 h-48 overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100 flex-shrink-0">
-            <ProductCardImage
-              src={product.image}
-              alt={product.name}
-              className="object-cover w-full h-full transition-transform duration-500 group-hover:scale-110"
-            />
-            
-            {/* Gradient Overlay */}
-            <div className="absolute inset-0 bg-gradient-to-t from-black/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-
-            {!product.inStock && (
-              <div className="absolute inset-0 bg-black/60 flex items-center justify-center backdrop-blur-sm">
-                <span className="bg-white text-gray-900 px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
-                  Fora de Estoque
-                </span>
-              </div>
-            )}
-          </div>
-        </Link>
-
-        <div className="flex-1 flex flex-col p-6 relative">
-          {/* Background Pattern */}
-          <div className="absolute top-0 right-0 w-16 h-16 opacity-5">
-            <svg viewBox="0 0 100 100" className="w-full h-full">
-              <image href="/images/noise/noise-red.svg" width="100%" height="100%" className="object-cover" />
-            </svg>
-          </div>
-          
-          <Link href={`/produtos/${product.slug}`} className="flex-1 relative z-10">
-            <div className="space-y-3">
-              <div className="flex items-start justify-between">
-                <h3 className="font-semibold text-gray-900 line-clamp-2 text-lg group-hover:text-red-600 transition-colors">
-                  {product.name}
-                </h3>
-              </div>
-              <div className="flex items-center space-x-2">
-                <span className="inline-block px-2 py-1 bg-red-50 text-red-600 text-xs font-medium rounded-full">
-                  {product.category}
-                </span>
-              </div>
-              <p className="text-sm text-gray-600 line-clamp-3 leading-relaxed">
-                {product.description}
-              </p>
-            </div>
-          </Link>
-
-          <div className="mt-6 flex items-center justify-between relative z-10">
-            <div className="space-y-2">
-              <span className="text-2xl font-bold text-gray-900">
-                {formatPrice(product.price)}
+      <div className="group relative flex h-full overflow-hidden rounded-xl border border-gray-100 bg-white transition duration-300 hover:-translate-y-1 hover:border-red-200 hover:shadow-xl">
+        <Link
+          href={`/produtos/${product.slug}`}
+          className="relative h-48 w-48 shrink-0 overflow-hidden bg-gray-100"
+        >
+          <ProductCardImage
+            src={product.image}
+            alt={product.name}
+            className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-105"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-black/10 to-transparent opacity-0 transition-opacity group-hover:opacity-100" />
+          {!product.inStock && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/60">
+              <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-gray-900">
+                Fora de Estoque
               </span>
-              <div className="flex items-center space-x-1">
-                {[1, 2, 3, 4, 5].map((star) => (
-                  <svg key={star} className="w-4 h-4 text-yellow-400 fill-current" viewBox="0 0 20 20">
-                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                  </svg>
-                ))}
-                <span className="text-xs text-gray-500 ml-1">(4.8)</span>
-              </div>
             </div>
-
+          )}
+        </Link>
+        <div className="relative flex flex-1 flex-col p-6">
+          <Link href={`/produtos/${product.slug}`} className="space-y-3">
+            <h3 className="text-lg font-semibold text-gray-900 group-hover:text-red-600">
+              {product.name}
+            </h3>
+            <span className="inline-block rounded-full bg-red-50 px-2 py-1 text-xs font-medium text-red-600">
+              {product.category}
+            </span>
+            <p className="line-clamp-3 text-sm leading-relaxed text-gray-600">
+              {product.description}
+            </p>
+          </Link>
+          <div className="mt-6 flex items-center justify-between">
+            <span className="text-2xl font-bold text-gray-900">
+              {formatPrice(product.price)}
+            </span>
             <div className="flex gap-3">
-              <Button 
-                size="sm" 
-                variant="outline" 
+              <Button
+                size="sm"
+                variant="outline"
                 onClick={handleWhatsApp}
-                className="border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 transition-colors"
+                className="border-red-200 text-red-600 hover:border-red-300 hover:bg-red-50"
               >
                 Orçamento
               </Button>
-              <button
+              <Button
+                size="sm"
                 onClick={handleAddToCart}
                 disabled={!product.inStock}
-                className="bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 disabled:bg-gray-300 text-white py-2 px-6 rounded-lg font-semibold transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105"
+                className="bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-300"
               >
                 {product.inStock ? 'Adicionar' : 'Indisponível'}
-              </button>
+              </Button>
             </div>
           </div>
         </div>
@@ -128,95 +100,53 @@ export function ProductCard({ product, viewMode = 'grid' }: ProductCardProps) {
   }
 
   return (
-    <div className="group bg-white rounded-xl overflow-hidden hover:shadow-2xl transition-all duration-500 h-full flex flex-col border border-gray-100 hover:border-red-200 hover:-translate-y-2">
-      <Link href={`/produtos/${product.slug}`}>
-        <div className="relative aspect-square overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100">
+    <div className="group relative">
+      <div className="aspect-square w-full overflow-hidden rounded-md bg-gray-100">
+        <Link href={`/produtos/${product.slug}`}>
           <ProductCardImage
             src={product.image}
             alt={product.name}
-            className="object-cover w-full h-full transition-transform duration-500 group-hover:scale-110"
+            className="h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
           />
-          
-          {/* Gradient Overlay */}
-          <div className="absolute inset-0 bg-gradient-to-t from-black/20 via-transparent to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
-          
-          {/* Heart/Favorite icon */}
-          <button className="absolute top-4 right-4 w-10 h-10 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center hover:bg-white hover:scale-110 transition-all duration-300 shadow-lg">
-            <svg className="w-5 h-5 text-gray-600 hover:text-red-500 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-            </svg>
-          </button>
-          
-          {/* Quick View Button */}
-          <button className="absolute top-4 left-4 w-10 h-10 bg-white/90 backdrop-blur-sm rounded-full flex items-center justify-center hover:bg-white hover:scale-110 transition-all duration-300 shadow-lg opacity-0 group-hover:opacity-100">
-            <Eye className="w-5 h-5 text-gray-600" />
-          </button>
-
-          {!product.inStock && (
-            <div className="absolute inset-0 bg-black/60 flex items-center justify-center backdrop-blur-sm">
-              <span className="bg-white text-gray-900 px-4 py-2 rounded-full text-sm font-semibold shadow-lg">
-                Fora de Estoque
-              </span>
-            </div>
-          )}
-        </div>
-      </Link>
-
-      <div className="p-5 flex-1 flex flex-col relative">
-        {/* Background Pattern */}
-        <div className="absolute bottom-0 right-0 w-12 h-12 opacity-5">
-          <svg viewBox="0 0 100 100" className="w-full h-full">
-            <image href="/images/noise/noise-red.svg" width="100%" height="100%" className="object-cover" />
-          </svg>
-        </div>
-        
-        <Link href={`/produtos/${product.slug}`} className="flex-1 relative z-10">
-          <div className="space-y-3">
-            <div className="flex items-center justify-between">
-              <span className="inline-block px-2 py-1 bg-red-50 text-red-600 text-xs font-medium rounded-full">
-                {product.category}
-              </span>
-            </div>
-            <h3 className="font-semibold text-gray-900 line-clamp-2 leading-tight text-lg group-hover:text-red-600 transition-colors">
-              {product.name}
-            </h3>
-          </div>
         </Link>
-        
-        <div className="mt-4 space-y-4 relative z-10">
-          <div className="flex items-center justify-between">
-            <span className="text-xl font-bold text-gray-900">
-              {formatPrice(product.price)}
+        {!product.inStock && (
+          <div className="absolute inset-0 flex items-center justify-center bg-black/60">
+            <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-gray-900">
+              Fora de Estoque
             </span>
-            <div className="flex items-center space-x-1">
-              {[1, 2, 3, 4, 5].map((star) => (
-                <svg key={star} className="w-4 h-4 text-yellow-400 fill-current" viewBox="0 0 20 20">
-                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" />
-                </svg>
-              ))}
-              <span className="text-xs text-gray-500 ml-1">(4.8)</span>
-            </div>
           </div>
-          
-          <div className="flex gap-2">
-            <Button 
-              size="sm" 
-              variant="outline" 
-              onClick={handleWhatsApp}
-              className="flex-1 h-10 border-red-200 text-red-600 hover:bg-red-50 hover:border-red-300 transition-colors font-medium"
-            >
-              Orçamento
-            </Button>
-            <Button
-              size="sm"
-              onClick={handleAddToCart}
-              disabled={!product.inStock}
-              className="flex-1 h-10 bg-gradient-to-r from-red-600 to-red-700 hover:from-red-700 hover:to-red-800 disabled:bg-gray-300 disabled:from-gray-300 disabled:to-gray-300 text-white font-medium transition-all duration-300 shadow-lg hover:shadow-xl transform hover:scale-105 flex items-center justify-center gap-1"
-            >
-              <ShoppingCart className="w-4 h-4" />
-              {product.inStock ? 'Adicionar' : 'Indisponível'}
-            </Button>
-          </div>
+        )}
+      </div>
+      <div className="mt-4 flex justify-between">
+        <div>
+          <h3 className="text-sm font-medium text-gray-900">
+            <Link href={`/produtos/${product.slug}`}>{product.name}</Link>
+          </h3>
+          <p className="mt-1 text-sm text-gray-500">{product.category}</p>
+        </div>
+        <p className="text-sm font-medium text-gray-900">
+          {formatPrice(product.price)}
+        </p>
+      </div>
+      <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+        <div className="flex gap-2">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleWhatsApp}
+            className="border-white text-white hover:bg-white hover:text-gray-900"
+          >
+            Orçamento
+          </Button>
+          <Button
+            size="sm"
+            onClick={handleAddToCart}
+            disabled={!product.inStock}
+            className="bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-300"
+          >
+            <ShoppingCart className="h-4 w-4" />
+            {product.inStock ? 'Adicionar' : 'Indisponível'}
+          </Button>
         </div>
       </div>
     </div>
@@ -228,20 +158,20 @@ export function ProductCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' |
     return (
       <Card className="overflow-hidden">
         <div className="flex">
-          <div className="w-32 h-32 bg-gray-200 animate-pulse flex-shrink-0" />
-          <div className="flex-1 p-4 flex justify-between">
+          <div className="h-32 w-32 shrink-0 animate-pulse bg-gray-200" />
+          <div className="flex flex-1 justify-between p-4">
             <div className="flex-1 space-y-2">
-              <div className="h-3 bg-gray-200 rounded animate-pulse w-1/4" />
-              <div className="h-5 bg-gray-200 rounded animate-pulse w-3/4" />
-              <div className="h-3 bg-gray-200 rounded animate-pulse w-full" />
-              <div className="h-3 bg-gray-200 rounded animate-pulse w-2/3" />
+              <div className="h-3 w-1/4 animate-pulse rounded bg-gray-200" />
+              <div className="h-5 w-3/4 animate-pulse rounded bg-gray-200" />
+              <div className="h-3 w-full animate-pulse rounded bg-gray-200" />
+              <div className="h-3 w-2/3 animate-pulse rounded bg-gray-200" />
             </div>
-            <div className="ml-4 flex flex-col justify-between items-end">
+            <div className="ml-4 flex flex-col items-end justify-between">
               <div className="space-y-1">
-                <div className="h-6 bg-gray-200 rounded animate-pulse w-20" />
-                <div className="h-3 bg-gray-200 rounded animate-pulse w-16" />
+                <div className="h-6 w-20 animate-pulse rounded bg-gray-200" />
+                <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
               </div>
-              <div className="h-8 bg-gray-200 rounded animate-pulse w-20" />
+              <div className="h-8 w-20 animate-pulse rounded bg-gray-200" />
             </div>
           </div>
         </div>
@@ -250,22 +180,23 @@ export function ProductCardSkeleton({ viewMode = 'grid' }: { viewMode?: 'grid' |
   }
 
   return (
-    <Card className="overflow-hidden h-full">
-      <div className="aspect-[4/3] bg-gray-200 animate-pulse" />
+    <Card className="h-full overflow-hidden">
+      <div className="aspect-square animate-pulse bg-gray-200" />
       <CardContent className="p-4">
         <div className="space-y-2">
-          <div className="h-3 bg-gray-200 rounded animate-pulse w-1/3" />
-          <div className="h-4 bg-gray-200 rounded animate-pulse w-full" />
-          <div className="h-3 bg-gray-200 rounded animate-pulse w-2/3" />
+          <div className="h-3 w-1/3 animate-pulse rounded bg-gray-200" />
+          <div className="h-4 w-full animate-pulse rounded bg-gray-200" />
+          <div className="h-3 w-2/3 animate-pulse rounded bg-gray-200" />
         </div>
       </CardContent>
-      <CardFooter className="p-4 pt-0 flex items-center justify-between">
+      <CardFooter className="flex items-center justify-between p-4 pt-0">
         <div className="space-y-1">
-          <div className="h-6 bg-gray-200 rounded animate-pulse w-20" />
-          <div className="h-3 bg-gray-200 rounded animate-pulse w-16" />
+          <div className="h-6 w-20 animate-pulse rounded bg-gray-200" />
+          <div className="h-3 w-16 animate-pulse rounded bg-gray-200" />
         </div>
-        <div className="h-8 bg-gray-200 rounded animate-pulse w-20" />
+        <div className="h-8 w-20 animate-pulse rounded bg-gray-200" />
       </CardFooter>
     </Card>
   );
 }
+

--- a/src/components/product/ProductGrid.tsx
+++ b/src/components/product/ProductGrid.tsx
@@ -11,18 +11,20 @@ interface ProductGridProps {
   viewMode?: 'grid' | 'list';
 }
 
-export function ProductGrid({ 
-  products, 
-  loading = false, 
+export function ProductGrid({
+  products,
+  loading = false,
   emptyMessage = 'Nenhum produto encontrado.',
-  viewMode = 'grid'
+  viewMode = 'grid',
 }: ProductGridProps) {
+  const gridClass =
+    viewMode === 'grid'
+      ? 'grid grid-cols-1 gap-y-10 gap-x-6 sm:grid-cols-2 lg:grid-cols-4 xl:gap-x-8'
+      : 'space-y-6';
+
   if (loading) {
     return (
-      <div className={viewMode === 'grid' 
-        ? "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"
-        : "space-y-6"
-      }>
+      <div className={gridClass}>
         {Array.from({ length: 8 }).map((_, index) => (
           <ProductCardSkeleton key={index} viewMode={viewMode} />
         ))}
@@ -32,102 +34,48 @@ export function ProductGrid({
 
   if (products.length === 0) {
     return (
-      <div className="relative flex flex-col items-center justify-center py-16 text-center">
-        {/* Background Pattern */}
-        <div className="absolute inset-0 opacity-5">
-          <svg viewBox="0 0 100 100" className="w-full h-full">
-            <image href="/images/waves.svg" width="100%" height="100%" className="object-cover" />
-          </svg>
-        </div>
-        
-        <div className="relative z-10">
-          <div className="w-32 h-32 bg-gradient-to-br from-red-50 to-red-100 rounded-full flex items-center justify-center mb-6 shadow-lg">
-            <svg
-              className="w-16 h-16 text-red-400"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={1.5}
-                d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2M4 13h2m13-8V4a1 1 0 00-1-1H7a1 1 0 00-1 1v1m8 0V4.5M9 5v-.5"
-              />
-            </svg>
-          </div>
-          <h3 className="text-2xl font-bold text-gray-900 mb-3">
-            Nenhum produto encontrado
-          </h3>
-          <p className="text-gray-600 max-w-md text-lg">
-            {emptyMessage}
-          </p>
-          <div className="mt-4 w-24 h-1 bg-gradient-to-r from-red-600 to-red-800 rounded-full mx-auto"></div>
-        </div>
+      <div className="py-16 text-center">
+        <h3 className="mb-3 text-2xl font-bold text-gray-900">
+          Nenhum produto encontrado
+        </h3>
+        <p className="text-lg text-gray-600">{emptyMessage}</p>
       </div>
     );
   }
 
   return (
-    <div className="relative">
-      {/* Background Elements */}
-      <div className="absolute top-0 left-0 w-32 h-32 opacity-3">
-        <svg viewBox="0 0 100 100" className="w-full h-full">
-          <image href="/images/noise/noise-red.svg" width="100%" height="100%" className="object-cover" />
-        </svg>
-      </div>
-      
-      <div className={viewMode === 'grid' 
-        ? "relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8"
-        : "relative z-10 space-y-6"
-      }>
-        {products.map((product) => (
-          <ProductCard key={product.id} product={product} viewMode={viewMode} />
-        ))}
-      </div>
+    <div className={gridClass}>
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} viewMode={viewMode} />
+      ))}
     </div>
   );
 }
 
 // Componente para exibir produtos em destaque
-export function FeaturedProductGrid({ 
-  products, 
-  loading = false 
-}: { 
-  products: Product[]; 
-  loading?: boolean; 
+export function FeaturedProductGrid({
+  products,
+  loading = false,
+}: {
+  products: Product[];
+  loading?: boolean;
 }) {
   if (loading) {
     return (
-      <div className="relative">
-        <div className="absolute top-0 right-0 w-24 h-24 opacity-5">
-          <svg viewBox="0 0 100 100" className="w-full h-full">
-            <image href="/images/waves.svg" width="100%" height="100%" className="object-cover" />
-          </svg>
-        </div>
-        <div className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-          {Array.from({ length: 4 }).map((_, index) => (
-            <ProductCardSkeleton key={index} />
-          ))}
-        </div>
+      <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 xl:gap-x-8">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <ProductCardSkeleton key={index} />
+        ))}
       </div>
     );
   }
 
   return (
-    <div className="relative">
-      {/* Background Pattern */}
-      <div className="absolute bottom-0 left-0 w-40 h-40 opacity-3">
-        <svg viewBox="0 0 100 100" className="w-full h-full">
-          <image href="/images/noise/noise-red.svg" width="100%" height="100%" className="object-cover" />
-        </svg>
-      </div>
-      
-      <div className="relative z-10 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-        {products.slice(0, 4).map((product) => (
-          <ProductCard key={product.id} product={product} />
-        ))}
-      </div>
+    <div className="grid grid-cols-1 gap-x-6 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 xl:gap-x-8">
+      {products.slice(0, 4).map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- align ProductGrid to Tailwind quick view markup
- streamline ProductCard structure and spacing

## Testing
- `npm run lint` (fails: Unexpected any)
- `npx tsc --noEmit` (fails: type errors)

------
https://chatgpt.com/codex/tasks/task_e_68b868a319e48331b7f24cae27de8016