### PR TITLE
feat: add banner carousel and modern product card design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,8 @@ import { Product } from "@/types";
 import { getProducts } from "@/services/wordpress";
 import { ScrollReveal } from "@/components/motion-primitives/scroll-reveal";
 import { motion } from "framer-motion";
-import HeroSection from "@/components/sections/HeroSection";
+import BannerCarousel from "@/components/sections/BannerCarousel";
+import { AnimatedText } from "@/components/motion-primitives/animated-text";
 
 export default function Home() {
     const [featuredProducts, setFeaturedProducts] = useState<Product[]>([]);
@@ -90,16 +91,7 @@ export default function Home() {
         <div className="min-h-screen bg-white">
             <Header />
 
-            <HeroSection
-                backgroundImage="/images/nihon-auto-template1.png"
-                productImage="/images/nihon-hiro.png"
-                productImageAlt="Acessórios automotivos"
-                title="NIHON"
-                highlight="ACESSÓRIOS"
-                subtitle="Excelência em peças automotivas de alta qualidade"
-                primaryAction={{ label: "Explorar Produtos", href: "/produtos" }}
-                secondaryAction={{ label: "Nossa História", href: "/sobre" }}
-            />
+            <BannerCarousel />
 
             {/* Marcas em Destaque com LogoCloud */}
             <ScrollReveal>
@@ -223,7 +215,7 @@ export default function Home() {
                             viewport={{ once: true }}
                         >
                             <h2 className="text-3xl md:text-4xl font-bold text-gray-900 mb-4">
-                                Números que <span className="text-red-600">Impressionam</span>
+                                Números que <span className="text-red-600"><AnimatedText text="Impressionam" /></span>
                             </h2>
                             <p className="text-lg text-gray-600 max-w-2xl mx-auto">
                                 Nossa trajetória de sucesso refletida em números
@@ -259,7 +251,7 @@ export default function Home() {
                                             }}
                                             viewport={{ once: true }}
                                         >
-                                            {stat.number}
+                                <AnimatedText text={stat.number} />
                                         </motion.div>
                                         <div className="text-gray-700 font-medium text-lg group-hover:text-red-700 transition-colors">
                                             {stat.label}
@@ -289,7 +281,7 @@ export default function Home() {
                             viewport={{ once: true }}
                         >
                             <h2 className="text-4xl md:text-5xl font-bold text-gray-900 mb-6">
-                                Por que escolher a <span className="text-red-600">Nihon?</span>
+                                Por que escolher a <span className="text-red-600"><AnimatedText text="Nihon?" /></span>
                             </h2>
                             <p className="text-xl text-gray-600 max-w-3xl mx-auto">
                                 Diferenciais que fazem toda a diferença na sua experiência

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -100,41 +100,39 @@ export function ProductCard({ product, viewMode = 'grid' }: ProductCardProps) {
   }
 
   return (
-    <div className="group relative">
-      <div className="aspect-square w-full overflow-hidden rounded-md bg-gray-100">
-        <Link href={`/produtos/${product.slug}`}>
+    <Card className="group relative overflow-hidden border border-gray-100 hover:shadow-lg transition-all">
+      <Link href={`/produtos/${product.slug}`}> 
+        <div className="aspect-square overflow-hidden bg-gray-100">
           <ProductCardImage
             src={product.image}
             alt={product.name}
             className="h-full w-full object-cover object-center transition-transform duration-300 group-hover:scale-105"
           />
-        </Link>
-        {!product.inStock && (
-          <div className="absolute inset-0 flex items-center justify-center bg-black/60">
-            <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-gray-900">
-              Fora de Estoque
-            </span>
-          </div>
-        )}
-      </div>
-      <div className="mt-4 flex justify-between">
-        <div>
-          <h3 className="text-sm font-medium text-gray-900">
-            <Link href={`/produtos/${product.slug}`}>{product.name}</Link>
-          </h3>
-          <p className="mt-1 text-sm text-gray-500">{product.category}</p>
+          {!product.inStock && (
+            <div className="absolute inset-0 flex items-center justify-center bg-black/60">
+              <span className="rounded-full bg-white px-4 py-2 text-sm font-semibold text-gray-900">
+                Fora de Estoque
+              </span>
+            </div>
+          )}
         </div>
-        <p className="text-sm font-medium text-gray-900">
+      </Link>
+      <CardContent className="p-4">
+        <h3 className="text-sm font-medium text-gray-900 mb-1">
+          <Link href={`/produtos/${product.slug}`}>{product.name}</Link>
+        </h3>
+        <p className="text-sm text-gray-500">{product.category}</p>
+      </CardContent>
+      <CardFooter className="flex items-center justify-between p-4 pt-0">
+        <span className="text-sm font-medium text-gray-900">
           {formatPrice(product.price)}
-        </p>
-      </div>
-      <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-        <div className="flex gap-2">
+        </span>
+        <div className="flex gap-2 opacity-0 transition-opacity group-hover:opacity-100">
           <Button
             size="sm"
             variant="outline"
             onClick={handleWhatsApp}
-            className="border-white text-white hover:bg-white hover:text-gray-900"
+            className="border-red-200 text-red-600 hover:bg-red-50"
           >
             Orçamento
           </Button>
@@ -144,12 +142,12 @@ export function ProductCard({ product, viewMode = 'grid' }: ProductCardProps) {
             disabled={!product.inStock}
             className="bg-red-600 text-white hover:bg-red-700 disabled:bg-gray-300"
           >
-            <ShoppingCart className="h-4 w-4" />
+            <ShoppingCart className="h-4 w-4 mr-1" />
             {product.inStock ? 'Adicionar' : 'Indisponível'}
           </Button>
         </div>
-      </div>
-    </div>
+      </CardFooter>
+    </Card>
   );
 }
 

--- a/src/components/sections/BannerCarousel.tsx
+++ b/src/components/sections/BannerCarousel.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Image from "next/image";
+import Link from "next/link";
+import { Swiper, SwiperSlide } from "swiper/react";
+import { Autoplay, Pagination, EffectFade } from "swiper/modules";
+import { Button } from "@/components/ui/button";
+import { AnimatedText } from "@/components/motion-primitives/animated-text";
+
+import "swiper/css";
+import "swiper/css/pagination";
+import "swiper/css/effect-fade";
+
+interface BannerItem {
+  id: string;
+  title: string;
+  highlight: string;
+  subtitle: string;
+  image: string;
+  cta: {
+    label: string;
+    href: string;
+  };
+}
+
+const banners: BannerItem[] = [
+  {
+    id: "acessorios",
+    title: "NIHON",
+    highlight: "ACESSÓRIOS",
+    subtitle: "Excelência em peças automotivas de alta qualidade",
+    image: "/images/nihon-auto-template1.png",
+    cta: { label: "Explorar Produtos", href: "/produtos" },
+  },
+  {
+    id: "historia",
+    title: "MAIS DE 38 ANOS",
+    highlight: "DE EXPERIÊNCIA",
+    subtitle: "Tradicionalidade que garante confiança em cada compra",
+    image: "/images/banner-02.jpg",
+    cta: { label: "Nossa História", href: "/sobre" },
+  },
+];
+
+export function BannerCarousel() {
+  return (
+    <section className="relative w-full h-[600px] overflow-hidden">
+      <Swiper
+        modules={[Autoplay, Pagination, EffectFade]}
+        autoplay={{ delay: 5000, disableOnInteraction: false }}
+        pagination={{ clickable: true }}
+        effect="fade"
+        className="h-full"
+      >
+        {banners.map((banner) => (
+          <SwiperSlide key={banner.id} className="relative h-full w-full">
+            <Image
+              src={banner.image}
+              alt=""
+              fill
+              priority
+              className="object-cover"
+            />
+            <div className="absolute inset-0 bg-black/40" />
+            <div className="relative z-10 flex h-full flex-col items-center justify-center text-center px-4">
+              <h1 className="text-5xl md:text-7xl font-bold text-white">
+                <AnimatedText text={banner.title} className="mr-2" />
+                <span className="text-red-500"><AnimatedText text={banner.highlight} delay={0.3} /></span>
+              </h1>
+              <p className="mt-6 text-lg text-gray-200 max-w-2xl">
+                {banner.subtitle}
+              </p>
+              <div className="mt-10">
+                <Link href={banner.cta.href}>
+                  <Button size="lg" className="bg-red-600 hover:bg-red-700 text-white">
+                    {banner.cta.label}
+                  </Button>
+                </Link>
+              </div>
+            </div>
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </section>
+  );
+}
+
+export default BannerCarousel;
+

--- a/src/components/sections/SupplierSections.tsx
+++ b/src/components/sections/SupplierSections.tsx
@@ -36,6 +36,16 @@ interface WordPressBrand {
   count: number;
 }
 
+interface WPProduct {
+  id: number;
+  name: string;
+  price: string;
+  images?: { src: string }[];
+  slug: string;
+  categories?: { name: string }[];
+  stock_status?: string;
+}
+
 export default function SupplierSections() {
   const [suppliers, setSuppliers] = useState<Supplier[]>([]);
   const [loading, setLoading] = useState(true);
@@ -56,7 +66,7 @@ export default function SupplierSections() {
               const wpProductsResponse = await productsResponse.json();
               const wpProducts = (wpProductsResponse.products || []).slice(0, 3);
 
-              const products: Product[] = wpProducts.map((product: any) => ({
+              const products: Product[] = wpProducts.map((product: WPProduct) => ({
                 id: product.id,
                 name: product.name,
                 price: parseFloat(product.price) || 0,
@@ -116,7 +126,7 @@ export default function SupplierSections() {
     <div className="container mx-auto px-4 py-8">
       <div className="text-center mb-12">
         <h2 className="text-3xl font-bold text-gray-900 mb-4">
-          Nossos <span className="text-blue-600">Fornecedores</span>
+          Nossos <span className="text-red-600">Fornecedores</span>
         </h2>
         <p className="text-gray-600 max-w-2xl mx-auto">
           Descubra produtos das marcas mais respeitadas do mercado.


### PR DESCRIPTION
## 🚀 Descrição
- substitui hero estático por carrossel de banners com animações
- moderniza card de produto e cores dos fornecedores
- aplica animações de texto nas seções de números e diferenciais

## 📱 Screenshots
- [ ] Mobile
- [ ] Tablet
- [ ] Desktop

## ✅ Checklist
- [ ] Componente responsivo testado
- [ ] Performance Lighthouse >95
- [ ] TypeScript sem erros


------
https://chatgpt.com/codex/tasks/task_e_68b871185e8c8331ad745786965066dc